### PR TITLE
refactor(export): re-export the structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ print(shapley.shapley_value(2)) # 20
 ```rust
 use std::collections::HashMap;
 
-use shapley::shapley::{Coalition, Shapley};
+use shapley::{Coalition, Shapley};
 
 fn main() {
     let players = vec![1, 2];

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 #[pyclass]
 struct Shapley {
-    inner: shapley::shapley::Shapley,
+    inner: shapley::Shapley,
 }
 
 #[pymethods]
@@ -13,11 +13,11 @@ impl Shapley {
     fn py_new(players: Vec<u64>, coalition_worth: HashMap<Vec<u64>, f64>) -> PyResult<Self> {
         let mut converted_worth = HashMap::new();
         for (members, worth) in coalition_worth {
-            let coalition = shapley::shapley::Coalition::new(members);
+            let coalition = shapley::Coalition::new(members);
             converted_worth.insert(coalition, worth);
         }
 
-        let inner = shapley::shapley::Shapley::new(players, converted_worth);
+        let inner = shapley::Shapley::new(players, converted_worth);
         Ok(Self { inner })
     }
 

--- a/crates/shapley/README.md
+++ b/crates/shapley/README.md
@@ -23,7 +23,7 @@ cargo add shapley
 ```rust
 use std::collections::HashMap;
 
-use shapley::shapley::{Coalition, Shapley};
+use shapley::{Coalition, Shapley};
 
 fn main() {
     let players = vec![1, 2];

--- a/crates/shapley/src/lib.rs
+++ b/crates/shapley/src/lib.rs
@@ -1,4 +1,4 @@
 #![doc = include_str!("../README.md")]
 
-
 pub mod shapley;
+pub use shapley::{Coalition, Shapley};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified import statements in documentation examples for easier usage.

* **New Features**
  * Users can now access key items directly from the crate namespace without referencing submodules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->